### PR TITLE
Add Move Row Up/Down buttons to column configuration

### DIFF
--- a/js/tb-megamenu.object.js
+++ b/js/tb-megamenu.object.js
@@ -353,6 +353,57 @@ Drupal.TBMegaMenu = Drupal.TBMegaMenu || {};
     show_toolbox($col);
   };
 
+  actions.rowUp = function() {
+    if ( !currentSelected ) {
+      return;
+    }
+    var $row = $(currentSelected.closest('.tb-megamenu-row'));
+    var $rows = $row.parent();
+    var $prevRow = $row.prev();
+    if ( $prevRow.length == 0 ) {
+      return;
+    }
+    var trow = $row.clone();
+    var trow1 = $prevRow.clone();
+    $row.replaceWith(trow1);
+    $prevRow.replaceWith(trow);
+
+    // Reset all events on new structure.
+    megamenu = $('#tb-megamenu-admin-mm-container').find('.tb-megamenu');
+    nav_items = megamenu.find('ul[class*="level"]>li>:first-child');
+    nav_subs = megamenu.find('.nav-child');
+    nav_cols = megamenu.find('[class*="span"]');
+    nav_all = nav_items.add(nav_subs).add(nav_cols);
+    bindEvents(nav_all);
+    currentSelected = $rows.find('.selected');
+  }
+
+  actions.rowDown = function() {
+    if ( !currentSelected ) {
+      return;
+    }
+    var $row = $(currentSelected.closest('.tb-megamenu-row'));
+    var $rows = $row.parent();
+    var $nextRow = $row.next();
+    if ( $nextRow.length == 0 ) {
+      return;
+    }
+    var trow = $row.clone();
+    var trow1 = $nextRow.clone();
+    $row.replaceWith(trow1);
+    $nextRow.replaceWith(trow);
+
+    // Reset all events on new structure.
+    megamenu = $('#tb-megamenu-admin-mm-container').find('.tb-megamenu');
+    nav_items = megamenu.find('ul[class*="level"]>li>:first-child');
+    nav_subs = megamenu.find('.nav-child');
+    nav_cols = megamenu.find('[class*="span"]');
+    nav_all = nav_items.add(nav_subs).add(nav_cols);
+    bindEvents(nav_all);
+
+    currentSelected = $rows.find('.selected');
+  }
+
   actions.addColumn = function() {
     if (!currentSelected) {
       return;

--- a/templates/backend/tb-megamenu-column-toolbox.html.twig
+++ b/templates/backend/tb-megamenu-column-toolbox.html.twig
@@ -5,8 +5,17 @@
     <li>
       <label class="hasTip" title="{{ 'Add/remove Column'|t }} - {{ 'Click + to add a new column on the right of the selected column. Click - to remove the selected column'|t }}">{{ 'Add/remove Column'|t }}</label>
       <fieldset class="btn-group">
-        <a href="" class="btn toolcol-addcol toolbox-action first" data-action="addColumn" title="{{ 'Add a new column on the right of the selected column'|t }}"><i class="icon-plus"></i></a>
-        <a href="" class="btn toolcol-removecol toolbox-action last" data-action="removeColumn" title="{{ 'Remove the selected column'|t }}"><i class="icon-minus"></i></a>
+        <a href="" class="btn toolcol-addcol toolbox-action first" data-action="addColumn" title="{{ 'Add a new column on the right of the selected column'|t }}"><i class="fa fa-plus"></i></a>
+        <a href="" class="btn toolcol-removecol toolbox-action last" data-action="removeColumn" title="{{ 'Remove the selected column'|t }}"><i class="fa fa-minus"></i></a>
+      </fieldset>
+    </li>
+  </ul>
+  <ul>
+    <li>
+      <label class="hasTip" title="{{ 'Move Row up/down'|t }} - {{ 'Click up arrow to move the selected row up. Click down arrow to move the selected row down'|t }}">{{ 'Move Row up/down'|t }}</label>
+      <fieldset class="btn-group">
+        <a href="" class="btn toolcol-addcol toolbox-action first" data-action="rowUp" title="{{ 'Move the selected row up'|t }}"><i class="fa fa-arrow-up"></i></a>
+        <a href="" class="btn toolcol-removecol toolbox-action last" data-action="rowDown" title="{{ 'Move the selected row downn'|t }}"><i class="fa fa-arrow-down"></i></a>
       </fieldset>
     </li>
   </ul>

--- a/templates/backend/tb-megamenu-item-toolbox.html.twig
+++ b/templates/backend/tb-megamenu-item-toolbox.html.twig
@@ -27,8 +27,8 @@
     <li>
       <label class="hasTip" title="{{ 'Break column'|t }} - {{ 'Move the item to the left/right column, create new column if there’s none on the chosen side.'|t }}">{{ 'Break column'|t }}</label>
       <fieldset class="btn-group">
-        <a href="" class="btn toolitem-moveleft toolbox-action" data-action="moveItemsLeft" title="{{ 'Move the items to the left column.'|t }}"><i class="icon-arrow-left"></i></a>
-        <a href="" class="btn toolitem-moveright toolbox-action" data-action="moveItemsRight" title="{{ 'Move the items to the right column.'|t }}"><i class="icon-arrow-right"></i></a>
+        <a href="" class="btn toolitem-moveleft toolbox-action" data-action="moveItemsLeft" title="{{ 'Move the items to the left column.'|t }}"><i class="fa fa-arrow-left"></i></a>
+        <a href="" class="btn toolitem-moveright toolbox-action" data-action="moveItemsRight" title="{{ 'Move the items to the right column.'|t }}"><i class="fa fa-arrow-right"></i></a>
       </fieldset>
     </li>
   </ul>
@@ -41,9 +41,9 @@
     </li>
   </ul>
   <ul>
-    <li title="{{ 'Icon'|t }} - {{ 'Add Icon for Menu Item. Click Icon label to visit Bootstrap icons page and get Icon Class. E.g.: icon-search'|t }}">
+    <li title="{{ 'Icon'|t }} - {{ 'Add Icon for Menu Item. Click Icon label to visit Bootstrap icons page and get Icon Class. E.g.: fa-search'|t }}">
       <label class="hasTip">
-        <a href="http://twitter.github.com/bootstrap/base-css.html#icons" target="_blank"><i class="icon-search"></i>{{ 'Icon'|t }}</a>
+        <a href="http://twitter.github.com/bootstrap/base-css.html#icons" target="_blank"><i class="fa fa-search"></i>{{ 'Icon'|t }}</a>
       </label>
       <fieldset class="">
         <input type="text" class="input-medium toolitem-xicon toolbox-input" name="toolitem-xicon" data-name="xicon" value="" />

--- a/templates/backend/tb-megamenu-submenu-toolbox.html.twig
+++ b/templates/backend/tb-megamenu-submenu-toolbox.html.twig
@@ -5,7 +5,7 @@
     <li title="{{ 'Add row'|t }} - {{ 'Add a new row to the selected submenu'|t }}">
       <label class="hasTip"> {{ 'Add row'|t }} </label>
       <fieldset class="btn-group">
-        <a href="" class="btn toolsub-addrow toolbox-action" data-action="addRow"><i class="icon-plus"></i></a>
+        <a href="" class="btn toolsub-addrow toolbox-action" data-action="addRow"><i class="fa fa-plus"></i></a>
       </fieldset>
     </li>
   </ul>
@@ -33,10 +33,10 @@
       <label class="hasTip">{{ 'Alignment'|t }}</label>
       <fieldset class="toolsub-alignment">
         <div class="btn-group">
-        <a class="btn toolsub-align-left toolbox-action" href="#" data-action="alignment" data-align="left" title="{{ 'Left'|t }}"><i class="icon-align-left"></i></a>
-        <a class="btn toolsub-align-right toolbox-action" href="#" data-action="alignment" data-align="right" title="{{ 'Right'|t }}"><i class="icon-align-right"></i></a>
-        <a class="btn toolsub-align-center toolbox-action" href="#" data-action="alignment" data-align="center" title="{{ 'Center'|t }}"><i class="icon-align-center"></i></a>
-        <a class="btn toolsub-align-justify toolbox-action" href="#" data-action="alignment" data-align="justify" title="{{ 'Justify'|t }}"><i class="icon-align-justify"></i></a>
+        <a class="btn toolsub-align-left toolbox-action" href="#" data-action="alignment" data-align="left" title="{{ 'Left'|t }}"><i class="fa fa-align-left"></i></a>
+        <a class="btn toolsub-align-right toolbox-action" href="#" data-action="alignment" data-align="right" title="{{ 'Right'|t }}"><i class="fa fa-align-right"></i></a>
+        <a class="btn toolsub-align-center toolbox-action" href="#" data-action="alignment" data-align="center" title="{{ 'Center'|t }}"><i class="fa fa-align-center"></i></a>
+        <a class="btn toolsub-align-justify toolbox-action" href="#" data-action="alignment" data-align="justify" title="{{ 'Justify'|t }}"><i class="fa fa-align-justify"></i></a>
         </div>
       </fieldset>
     </li>


### PR DESCRIPTION
Inspired by D7 Issue #[2116485](https://www.drupal.org/node/2116485) but is a complete re-write for D8.

This adds "Move row up / Move row down" buttons to the Column Configuration toolbox.  If you have more than one row in the submenu area, you can now select a column in the row and move it up or down.  Ignores requests if top row is "move up" / bottom row is "moved down".

Use case for this is to allow for column titles via blocks or just to have block content above the links.

Note: This requests also includes the template updates to use FontAwesome 4.x icons (Issue #4 ).
